### PR TITLE
Add tag/folder support for categorisation

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -63,21 +63,38 @@ Permanently reorders the stored cards in your inventory or wishlist by the chose
 
 ### Listing cards: `list`
 
-Displays all cards in the current list.
+Displays all cards in the current list, or only cards with a specific tag/folder.
 
-**Format:** `list`
+**Format:** `list [/t TAG]`
+
+**Examples:**
+`list`
+`list /t sealed`
 
 ### Finding cards: `find`
 
-Searches the current list by name, price, quantity, optional metadata, or any combination of them.
+Searches the current list by name, price, quantity, optional metadata, tags/folders, or any combination of them.
 
-**Format:** `find [/n NAME] [/p PRICE] [/q QUANTITY] [/s SET] [/r RARITY] [/c CONDITION] [/l LANGUAGE] [/no CARD_NUMBER]`
+**Format:** `find [/n NAME] [/p PRICE] [/q QUANTITY] [/s SET] [/r RARITY] [/c CONDITION] [/l LANGUAGE] [/no CARD_NUMBER] [/t TAG]`
 
 **Examples:**
 `find /n pika`
 `find /p 5.99`
 `find /n charizard /q 2`
 `find /s Base Set /r Rare`
+`find /t trade`
+
+### Tagging a card: `tag` or `folder`
+
+Adds or removes an optional tag/folder label on an existing card. Tags are lightweight labels such as `deck`,
+`sealed`, or `trade`, and you can use them later with `find /t ...` or `list /t ...`.
+
+**Format:** `tag add INDEX /t TAG`
+**Format:** `tag remove INDEX /t TAG`
+
+**Examples:**
+`tag add 3 /t deck`
+`folder remove 2 /t trade`
 
 ### Removing a card by index: `removeindex`
 
@@ -179,11 +196,13 @@ Exits the application.
 | `removeindex INDEX` | Remove by index |
 | `removename NAME` | Remove by name |
 | `history [...]` | View history |
+| `tag add INDEX /t TAG` | Add tag/folder |
+| `tag remove INDEX /t TAG` | Remove tag/folder |
 | `wishlist acquired INDEX` | Move to inventory |
 | `download /f FILE_PATH` | Export data |
 | `upload /f FILE_PATH` | Import data |
 | `undoupload` | Undo upload |
 | `wishlist <command>` | Use wishlist |
-| `list` | List cards |
+| `list [/t TAG]` | List cards |
 | `find [...]` | Search cards |
 | `bye` | Exit app |

--- a/src/main/java/seedu/cardcollector/Storage.java
+++ b/src/main/java/seedu/cardcollector/Storage.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import java.util.UUID;
 
 public class Storage {
+    private static final String FILE_HEADER_V4 = "CARDCOLLECTOR_STORAGE_V4";
     private static final String FILE_HEADER_V3 = "CARDCOLLECTOR_STORAGE_V3";
     private static final String FILE_HEADER_V2 = "CARDCOLLECTOR_STORAGE_V2";
     private static final String NULL_VALUE = "-";
@@ -76,7 +77,7 @@ public class Storage {
         }
 
         ArrayList<String> lines = new ArrayList<>();
-        lines.add(FILE_HEADER_V3);
+        lines.add(FILE_HEADER_V4);
         appendSection(lines, "inventory", state.getInventory().getCards());
         appendSection(lines, "inventory_history", state.getInventory().getHistory().getFlattenedCards());
         appendSection(lines, "wishlist", state.getWishlist().getCards());
@@ -121,6 +122,7 @@ public class Storage {
                 serializeText(card.getCondition()),
                 serializeText(card.getLanguage()),
                 serializeText(card.getCardNumber()),
+                serializeTags(card.getTags()),
                 serializeInstant(card.getLastAdded()),
                 serializeInstant(card.getLastModified()),
                 serializeInstant(card.getLastRemoved()));
@@ -132,7 +134,7 @@ public class Storage {
         }
 
         String[] parts = line.split("\t", -1);
-        if (parts.length != 7 && parts.length != 12) {
+        if (parts.length != 7 && parts.length != 12 && parts.length != 13) {
             throw new IOException("Malformed card record");
         }
 
@@ -141,12 +143,15 @@ public class Storage {
             String name = new String(Base64.getDecoder().decode(parts[1]), StandardCharsets.UTF_8);
             int quantity = Integer.parseInt(parts[2]);
             float price = Float.parseFloat(parts[3]);
-            String cardSet = parts.length == 12 ? parseText(parts[4]) : null;
-            String rarity = parts.length == 12 ? parseText(parts[5]) : null;
-            String condition = parts.length == 12 ? parseText(parts[6]) : null;
-            String language = parts.length == 12 ? parseText(parts[7]) : null;
-            String cardNumber = parts.length == 12 ? parseText(parts[8]) : null;
-            int instantStartIndex = parts.length == 12 ? 9 : 4;
+            String cardSet = parts.length >= 12 ? parseText(parts[4]) : null;
+            String rarity = parts.length >= 12 ? parseText(parts[5]) : null;
+            String condition = parts.length >= 12 ? parseText(parts[6]) : null;
+            String language = parts.length >= 12 ? parseText(parts[7]) : null;
+            String cardNumber = parts.length >= 12 ? parseText(parts[8]) : null;
+            java.util.LinkedHashSet<String> tags = parts.length == 13
+                    ? parseTags(parts[9])
+                    : new java.util.LinkedHashSet<>();
+            int instantStartIndex = parts.length == 13 ? 10 : (parts.length == 12 ? 9 : 4);
             Instant lastAdded = parseInstant(parts[instantStartIndex]);
             Instant lastModified = parseInstant(parts[instantStartIndex + 1]);
             Instant lastRemoved = parseInstant(parts[instantStartIndex + 2]);
@@ -161,6 +166,7 @@ public class Storage {
                     .condition(condition)
                     .language(language)
                     .cardNumber(cardNumber)
+                    .tags(tags)
                     .lastAdded(lastAdded)
                     .lastModified(lastModified)
                     .lastRemoved(lastRemoved)
@@ -192,7 +198,30 @@ public class Storage {
         return new String(Base64.getDecoder().decode(value), StandardCharsets.UTF_8);
     }
 
+    private static String serializeTags(java.util.Collection<String> tags) {
+        if (tags == null || tags.isEmpty()) {
+            return NULL_VALUE;
+        }
+
+        return Base64.getEncoder().encodeToString(String.join("\n", tags).getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static java.util.LinkedHashSet<String> parseTags(String value) {
+        java.util.LinkedHashSet<String> tags = new java.util.LinkedHashSet<>();
+        if (NULL_VALUE.equals(value)) {
+            return tags;
+        }
+
+        String decoded = new String(Base64.getDecoder().decode(value), StandardCharsets.UTF_8);
+        for (String tag : decoded.split("\n")) {
+            if (!tag.isBlank()) {
+                tags.add(tag);
+            }
+        }
+        return tags;
+    }
+
     private static boolean isSupportedHeader(String header) {
-        return FILE_HEADER_V2.equals(header) || FILE_HEADER_V3.equals(header);
+        return FILE_HEADER_V2.equals(header) || FILE_HEADER_V3.equals(header) || FILE_HEADER_V4.equals(header);
     }
 }

--- a/src/main/java/seedu/cardcollector/Ui.java
+++ b/src/main/java/seedu/cardcollector/Ui.java
@@ -191,6 +191,45 @@ public class Ui {
         printBorder();
     }
 
+    public void printTaggedList(ArrayList<Card> results, String tag) {
+        assert results != null : "Results list passed to Ui should not be null";
+
+        printBorder();
+        if (results.isEmpty()) {
+            System.out.println("No cards found with tag \"" + tag + "\".");
+        } else {
+            System.out.println("Here are the cards tagged \"" + tag + "\"!");
+            for (int i = 0; i < results.size(); i++) {
+                System.out.println((i + 1) + ". " + results.get(i));
+            }
+        }
+        printBorder();
+    }
+
+    public void printTagUpdated(CardsList list, int index, String tag, String action) {
+        printBorder();
+        System.out.println("I have " + toPastTense(action) + " tag \"" + tag + "\" for card " + (index + 1) + "!");
+        System.out.println(list.getCard(index));
+        printBorder();
+    }
+
+    public void printTagNoChange(Card card, String tag, String action) {
+        printBorder();
+        System.out.println("No tag change: \"" + tag + "\" was not " + toPastTense(action) + ".");
+        System.out.println(card);
+        printBorder();
+    }
+
+    private static String toPastTense(String action) {
+        if ("remove".equals(action)) {
+            return "removed";
+        }
+        if ("add".equals(action)) {
+            return "added";
+        }
+        return action;
+    }
+
     public void printUndoSuccess(CardsList list) {
         printBorder();
         System.out.println("Undo Successful!");
@@ -345,4 +384,3 @@ public class Ui {
     }
 
 }
-

--- a/src/main/java/seedu/cardcollector/card/Card.java
+++ b/src/main/java/seedu/cardcollector/card/Card.java
@@ -1,6 +1,10 @@
 package seedu.cardcollector.card;
 
 import java.time.Instant;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.StringJoiner;
 import java.util.UUID;
 
 public class Card {
@@ -13,6 +17,7 @@ public class Card {
     private String condition;
     private String language;
     private String cardNumber;
+    private LinkedHashSet<String> tags;
     private Instant lastAdded = null;    // lastAdded is a nullable type
     private Instant lastModified = null; // lastModified is a nullable type
     private Instant lastRemoved = null;  // lastRemoved is a nullable type
@@ -27,6 +32,7 @@ public class Card {
         this.condition = builder.condition;
         this.language = builder.language;
         this.cardNumber = builder.cardNumber;
+        this.tags = new LinkedHashSet<>(builder.tags);
         this.lastAdded = builder.lastAdded;
         this.lastModified = builder.lastModified;
         this.lastRemoved = builder.lastRemoved;
@@ -42,6 +48,7 @@ public class Card {
         private String condition;
         private String language;
         private String cardNumber;
+        private LinkedHashSet<String> tags = new LinkedHashSet<>();
         private Instant lastAdded;
         private Instant lastModified;
         private Instant lastRemoved;
@@ -88,6 +95,26 @@ public class Card {
 
         public Builder cardNumber(String cardNumber) {
             this.cardNumber = cardNumber;
+            return this;
+        }
+
+        public Builder tags(Collection<String> tags) {
+            this.tags = new LinkedHashSet<>();
+            if (tags == null) {
+                return this;
+            }
+
+            for (String tag : tags) {
+                addTag(tag);
+            }
+            return this;
+        }
+
+        public Builder addTag(String tag) {
+            String normalizedTag = normalizeTag(tag);
+            if (normalizedTag != null && !containsTagIgnoreCase(tags, normalizedTag)) {
+                this.tags.add(normalizedTag);
+            }
             return this;
         }
 
@@ -189,6 +216,52 @@ public class Card {
         this.cardNumber = cardNumber;
     }
 
+    public LinkedHashSet<String> getTags() {
+        return new LinkedHashSet<>(tags);
+    }
+
+    public void setTags(Collection<String> tags) {
+        this.tags = new LinkedHashSet<>();
+        if (tags == null) {
+            return;
+        }
+
+        for (String tag : tags) {
+            addTag(tag);
+        }
+    }
+
+    public boolean addTag(String tag) {
+        String normalizedTag = normalizeTag(tag);
+        if (normalizedTag == null || containsTagIgnoreCase(tags, normalizedTag)) {
+            return false;
+        }
+        tags.add(normalizedTag);
+        return true;
+    }
+
+    public boolean removeTag(String tag) {
+        String normalizedTag = normalizeTag(tag);
+        if (normalizedTag == null) {
+            return false;
+        }
+
+        Iterator<String> iterator = tags.iterator();
+        while (iterator.hasNext()) {
+            String existingTag = iterator.next();
+            if (existingTag.equalsIgnoreCase(normalizedTag)) {
+                iterator.remove();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public boolean hasTag(String tag) {
+        String normalizedTag = normalizeTag(tag);
+        return normalizedTag != null && containsTagIgnoreCase(tags, normalizedTag);
+    }
+
     public Instant getLastAdded() {
         return lastAdded;
     }
@@ -225,6 +298,7 @@ public class Card {
                 .condition(condition)
                 .language(language)
                 .cardNumber(cardNumber)
+                .tags(tags)
                 .lastAdded(lastAdded)
                 .lastModified(lastModified)
                 .lastRemoved(lastRemoved)
@@ -245,6 +319,7 @@ public class Card {
         appendMetadata(builder, "Condition", condition);
         appendMetadata(builder, "Language", language);
         appendMetadata(builder, "Card No.", cardNumber);
+        appendMetadata(builder, "Tags", formatTags(tags));
 
         return builder.toString();
     }
@@ -254,5 +329,35 @@ public class Card {
             return;
         }
         builder.append(" | ").append(label).append(": ").append(value);
+    }
+
+    private static String normalizeTag(String tag) {
+        if (tag == null) {
+            return null;
+        }
+
+        String trimmed = tag.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    private static boolean containsTagIgnoreCase(Collection<String> tags, String tag) {
+        for (String existingTag : tags) {
+            if (existingTag.equalsIgnoreCase(tag)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String formatTags(Collection<String> tags) {
+        if (tags == null || tags.isEmpty()) {
+            return null;
+        }
+
+        StringJoiner joiner = new StringJoiner(", ");
+        for (String tag : tags) {
+            joiner.add(tag);
+        }
+        return joiner.toString();
     }
 }

--- a/src/main/java/seedu/cardcollector/card/CardHistoryEntry.java
+++ b/src/main/java/seedu/cardcollector/card/CardHistoryEntry.java
@@ -1,6 +1,8 @@
 package seedu.cardcollector.card;
 
+import java.util.Collection;
 import java.util.LinkedHashMap;
+import java.util.StringJoiner;
 
 public class CardHistoryEntry {
     private final CardHistoryType cardHistoryType;
@@ -103,6 +105,7 @@ public class CardHistoryEntry {
         addTextChange(changedFields, "condition", previous.getCondition(), current.getCondition());
         addTextChange(changedFields, "language", previous.getLanguage(), current.getLanguage());
         addTextChange(changedFields, "card number", previous.getCardNumber(), current.getCardNumber());
+        addTextChange(changedFields, "tags", formatTags(previous.getTags()), formatTags(current.getTags()));
 
         return changedFields;
     }
@@ -118,5 +121,17 @@ public class CardHistoryEntry {
 
     private static String displayValue(String value) {
         return value == null || value.isBlank() ? "-" : value;
+    }
+
+    private static String formatTags(Collection<String> tags) {
+        if (tags == null || tags.isEmpty()) {
+            return null;
+        }
+
+        StringJoiner joiner = new StringJoiner(", ");
+        for (String tag : tags) {
+            joiner.add(tag);
+        }
+        return joiner.toString();
     }
 }

--- a/src/main/java/seedu/cardcollector/card/CardsList.java
+++ b/src/main/java/seedu/cardcollector/card/CardsList.java
@@ -150,7 +150,7 @@ public class CardsList {
     }
 
     public ArrayList<Card> findCards(String name, Float price, Integer quantity,
-            String cardSet, String rarity, String condition, String language, String cardNumber) {
+            String cardSet, String rarity, String condition, String language, String cardNumber, String tag) {
         assert cards != null : "Cards inventory should be initialized before searching";
 
         ArrayList<Card> results = new ArrayList<>();
@@ -178,6 +178,9 @@ public class CardsList {
                 matches = false;
             }
             if (!containsIgnoreCase(card.getCardNumber(), cardNumber)) {
+                matches = false;
+            }
+            if (!containsTagIgnoreCase(card, tag)) {
                 matches = false;
             }
             if (matches) {
@@ -271,6 +274,36 @@ public class CardsList {
         return quantityChanged || anyFieldChanged;
     }
 
+    public boolean addTag(int index, String tag) {
+        assert index >= 0 && index < cards.size() : "Index should be validated before calling addTag";
+
+        Card card = cards.get(index);
+        Card originalCard = card.copy();
+        boolean changed = card.addTag(tag);
+        if (!changed) {
+            return false;
+        }
+
+        card.setLastModified(Instant.now());
+        history.add(originalCard, card.copy());
+        return true;
+    }
+
+    public boolean removeTag(int index, String tag) {
+        assert index >= 0 && index < cards.size() : "Index should be validated before calling removeTag";
+
+        Card card = cards.get(index);
+        Card originalCard = card.copy();
+        boolean changed = card.removeTag(tag);
+        if (!changed) {
+            return false;
+        }
+
+        card.setLastModified(Instant.now());
+        history.add(originalCard, card.copy());
+        return true;
+    }
+
     private static boolean isSameCardVariant(Card first, Card second) {
         return first.getName().equalsIgnoreCase(second.getName())
                 && first.getPrice() == second.getPrice()
@@ -289,6 +322,13 @@ public class CardsList {
             return false;
         }
         return actualValue.toLowerCase(Locale.ROOT).contains(expectedFragment.toLowerCase(Locale.ROOT));
+    }
+
+    private static boolean containsTagIgnoreCase(Card card, String expectedTag) {
+        if (expectedTag == null) {
+            return true;
+        }
+        return card.hasTag(expectedTag);
     }
 
     private static boolean isUpdatedTextValue(String candidate, String currentValue) {

--- a/src/main/java/seedu/cardcollector/command/FindCommand.java
+++ b/src/main/java/seedu/cardcollector/command/FindCommand.java
@@ -13,9 +13,10 @@ public class FindCommand extends Command {
     private final String condition;
     private final String language;
     private final String cardNumber;
+    private final String tag;
 
     public FindCommand(String name, Float price, Integer quantity,
-            String cardSet, String rarity, String condition, String language, String cardNumber) {
+            String cardSet, String rarity, String condition, String language, String cardNumber, String tag) {
         this.name = name;
         this.price = price;
         this.quantity = quantity;
@@ -24,6 +25,7 @@ public class FindCommand extends Command {
         this.condition = condition;
         this.language = language;
         this.cardNumber = cardNumber;
+        this.tag = tag;
     }
 
     @Override
@@ -31,7 +33,7 @@ public class FindCommand extends Command {
         var ui = context.getUi();
         var inventory = context.getTargetList();
         ArrayList<Card> results = inventory.findCards(
-                name, price, quantity, cardSet, rarity, condition, language, cardNumber);
+                name, price, quantity, cardSet, rarity, condition, language, cardNumber, tag);
         ui.printFound(results);
         return new CommandResult(false);
     }

--- a/src/main/java/seedu/cardcollector/command/ListCommand.java
+++ b/src/main/java/seedu/cardcollector/command/ListCommand.java
@@ -1,9 +1,30 @@
 package seedu.cardcollector.command;
 
+import seedu.cardcollector.card.Card;
+
+import java.util.ArrayList;
+
 public class ListCommand extends Command {
+    private final String tag;
+
+    public ListCommand() {
+        this(null);
+    }
+
+    public ListCommand(String tag) {
+        this.tag = tag;
+    }
+
     @Override
     public CommandResult execute(CommandContext context) {
-        context.getUi().printList(context.getTargetList());
+        if (tag == null) {
+            context.getUi().printList(context.getTargetList());
+            return new CommandResult(false);
+        }
+
+        ArrayList<Card> results = context.getTargetList().findCards(
+                null, null, null, null, null, null, null, null, tag);
+        context.getUi().printTaggedList(results, tag);
         return new CommandResult(false);
     }
 }

--- a/src/main/java/seedu/cardcollector/command/TagCommand.java
+++ b/src/main/java/seedu/cardcollector/command/TagCommand.java
@@ -1,0 +1,57 @@
+package seedu.cardcollector.command;
+
+import seedu.cardcollector.card.Card;
+
+public class TagCommand extends Command {
+    public enum Operation {
+        ADD,
+        REMOVE
+    }
+
+    private final Operation operation;
+    private final int targetIndex;
+    private final String tag;
+
+    public TagCommand(Operation operation, int targetIndex, String tag) {
+        this.operation = operation;
+        this.targetIndex = targetIndex;
+        this.tag = tag;
+        this.isReversible = true;
+    }
+
+    @Override
+    public CommandResult execute(CommandContext context) {
+        var ui = context.getUi();
+        var cards = context.getTargetList();
+        if (targetIndex < 0 || targetIndex >= cards.getSize()) {
+            ui.printInvalidIndex();
+            return new CommandResult(false, false);
+        }
+
+        Card card = cards.getCard(targetIndex);
+        boolean changed = switch (operation) {
+        case ADD -> cards.addTag(targetIndex, tag);
+        case REMOVE -> cards.removeTag(targetIndex, tag);
+        };
+
+        this.isReversible = changed;
+        if (!changed) {
+            ui.printTagNoChange(card, tag, operation.name().toLowerCase());
+            return new CommandResult(false, false);
+        }
+
+        ui.printTagUpdated(cards, targetIndex, tag, operation.name().toLowerCase());
+        return new CommandResult(false);
+    }
+
+    @Override
+    public CommandResult undo(CommandContext context) {
+        switch (operation) {
+        case ADD -> context.getTargetList().removeTag(targetIndex, tag);
+        case REMOVE -> context.getTargetList().addTag(targetIndex, tag);
+        default -> throw new IllegalStateException("Unexpected operation: " + operation);
+        }
+        context.getUi().printUndoSuccess(context.getTargetList());
+        return new CommandResult(false);
+    }
+}

--- a/src/main/java/seedu/cardcollector/parsing/Parser.java
+++ b/src/main/java/seedu/cardcollector/parsing/Parser.java
@@ -15,6 +15,7 @@ import seedu.cardcollector.command.ListCommand;
 import seedu.cardcollector.command.RemoveCardByIndexCommand;
 import seedu.cardcollector.command.RemoveCardByNameCommand;
 import seedu.cardcollector.command.ReorderCommand;
+import seedu.cardcollector.command.TagCommand;
 import seedu.cardcollector.command.UndoCommand;
 import seedu.cardcollector.command.UndoUploadCommand;
 import seedu.cardcollector.command.UploadCommand;
@@ -35,8 +36,10 @@ public class Parser {
     private static final String FLAG_LANGUAGE = "/l";
     private static final String FLAG_CARD_NUMBER = "/no";
     private static final String FLAG_ID = "/id";
+    private static final String FLAG_TAG = "/t";
     private static final String[] CARD_FIELD_FLAGS = {
-        FLAG_NAME, FLAG_QUANTITY, FLAG_PRICE, FLAG_SET, FLAG_RARITY, FLAG_CONDITION, FLAG_LANGUAGE, FLAG_CARD_NUMBER
+        FLAG_NAME, FLAG_QUANTITY, FLAG_PRICE, FLAG_SET, FLAG_RARITY, FLAG_CONDITION, FLAG_LANGUAGE, FLAG_CARD_NUMBER,
+        FLAG_TAG
     };
     private static final String[] ADD_FIELD_FLAGS = {
         FLAG_NAME, FLAG_QUANTITY, FLAG_PRICE, FLAG_SET, FLAG_RARITY, FLAG_CONDITION, FLAG_LANGUAGE, FLAG_CARD_NUMBER,
@@ -58,6 +61,8 @@ public class Parser {
     private static final String KEYWORD_UNDO_UPLOAD_COMMAND = "undoupload";
     private static final String KEYWORD_REORDER_COMMAND = "reorder";
     private static final String KEYWORD_UNDO_COMMAND = "undo";
+    private static final String KEYWORD_TAG_COMMAND = "tag";
+    private static final String KEYWORD_FOLDER_COMMAND = "folder";
 
     private static final String[] USAGE_REORDER_COMMAND = {
         "reorder CRITERIA [asc|desc]",
@@ -72,17 +77,26 @@ public class Parser {
     };
 
     private static final String[] USAGE_FIND_COMMAND = {
-        "find [/n NAME] [/p PRICE] [/q QUANTITY] [/s SET] [/r RARITY] [/c CONDITION] [/l LANGUAGE] [/no CARD_NUMBER]",
+        "find [/n NAME] [/p PRICE] [/q QUANTITY] [/s SET] [/r RARITY] [/c CONDITION] [/l LANGUAGE] "
+                + "[/no CARD_NUMBER] [/t TAG]",
         "find /n Pikachu",
         "find /p 12.5",
         "find /n Pikachu /q 3",
-        "find /s Base Set /r Rare"
+        "find /s Base Set /r Rare",
+        "find /t trade"
     };
 
     private static final String[] USAGE_ADD_COMMAND = {
         "add /n NAME /q QTY /p PRICE [/s SET] [/r RARITY] [/c CONDITION] [/l LANGUAGE] [/no CARD_NUMBER]",
         "add /n Pikachu /q 1 /p 5.5",
         "add /n Charizard /q 1 /p 99.99 /s Base Set /r Holo /c Near Mint /l English /no 4/102"
+    };
+
+    private static final String[] USAGE_TAG_COMMAND = {
+        "tag add INDEX /t TAG",
+        "tag remove INDEX /t TAG",
+        "tag add 3 /t deck",
+        "folder remove 2 /t trade"
     };
 
     private static final String[] USAGE_EDIT_COMMAND = {
@@ -142,6 +156,9 @@ public class Parser {
             return handleReorder(arguments);
         case KEYWORD_UNDO_COMMAND:
             return handleUndo(arguments);
+        case KEYWORD_TAG_COMMAND:
+        case KEYWORD_FOLDER_COMMAND:
+            return handleTag(arguments);
         default:
             throw new ParseUnknownCommandException(commandKeyword);
         }
@@ -224,6 +241,7 @@ public class Parser {
         String condition = null;
         String language = null;
         String cardNumber = null;
+        String tag = null;
 
         try {
             name = optionalTextFlag(arguments, FLAG_NAME, CARD_FIELD_FLAGS);
@@ -240,6 +258,7 @@ public class Parser {
             condition = optionalTextFlag(arguments, FLAG_CONDITION, CARD_FIELD_FLAGS);
             language = optionalTextFlag(arguments, FLAG_LANGUAGE, CARD_FIELD_FLAGS);
             cardNumber = optionalTextFlag(arguments, FLAG_CARD_NUMBER, CARD_FIELD_FLAGS);
+            tag = optionalTextFlag(arguments, FLAG_TAG, CARD_FIELD_FLAGS);
         } catch (NumberFormatException e) {
             throw new ParseInvalidArgumentException(
                     "Invalid number format for price or quantity",
@@ -254,24 +273,38 @@ public class Parser {
 
         if (name == null && price == null && quantity == null
                 && cardSet == null && rarity == null && condition == null
-                && language == null && cardNumber == null) {
+                && language == null && cardNumber == null && tag == null) {
             throw new ParseInvalidArgumentException(
                     "At least one search field must be provided",
                     USAGE_FIND_COMMAND
             );
         }
 
-        return new FindCommand(name, price, quantity, cardSet, rarity, condition, language, cardNumber);
+        return new FindCommand(name, price, quantity, cardSet, rarity, condition, language, cardNumber, tag);
     }
 
     private Command handleList(String arguments) throws ParseInvalidArgumentException {
-        if (!arguments.isBlank()) {
+        if (arguments.isBlank()) {
+            return new ListCommand();
+        }
+
+        String tag;
+        try {
+            tag = optionalTextFlag(arguments, FLAG_TAG, new String[] {FLAG_TAG});
+        } catch (Exception e) {
             throw new ParseInvalidArgumentException(
-                    "list does not take any arguments",
-                    new String[] {"list"}
+                    "Invalid list format",
+                    new String[] {"list", "list /t sealed"}
             );
         }
-        return new ListCommand();
+
+        if (tag == null) {
+            throw new ParseInvalidArgumentException(
+                    "list only supports optional /t TAG filtering",
+                    new String[] {"list", "list /t sealed"}
+            );
+        }
+        return new ListCommand(tag);
     }
 
     private Command handleExit(String arguments) throws ParseInvalidArgumentException {
@@ -495,6 +528,45 @@ public class Parser {
         }
 
         return new EditCommand(index, name, quantity, price, cardSet, rarity, condition, language, cardNumber);
+    }
+
+    private Command handleTag(String arguments) throws ParseInvalidArgumentException {
+        if (arguments.isBlank()) {
+            throw new ParseInvalidArgumentException("Missing tag action", USAGE_TAG_COMMAND);
+        }
+
+        String[] parts = arguments.trim().split(REGEX_WHITESPACES, 2);
+        if (parts.length < 2) {
+            throw new ParseInvalidArgumentException("Missing tag target", USAGE_TAG_COMMAND);
+        }
+
+        TagCommand.Operation operation;
+        if ("add".startsWith(parts[0].toLowerCase())) {
+            operation = TagCommand.Operation.ADD;
+        } else if ("remove".startsWith(parts[0].toLowerCase())) {
+            operation = TagCommand.Operation.REMOVE;
+        } else {
+            throw new ParseInvalidArgumentException("Unknown tag action", USAGE_TAG_COMMAND);
+        }
+
+        String targetArgs = parts[1].trim();
+        int tagFlagIndex = indexOfFlag(targetArgs, FLAG_TAG);
+        if (tagFlagIndex < 0) {
+            throw new ParseInvalidArgumentException("Tag must be provided with /t", USAGE_TAG_COMMAND);
+        }
+
+        String indexText = targetArgs.substring(0, tagFlagIndex).trim();
+        if (indexText.isBlank()) {
+            throw new ParseInvalidArgumentException("Index must be provided", USAGE_TAG_COMMAND);
+        }
+
+        try {
+            int index = Integer.parseInt(indexText) - 1;
+            String tag = requireTextFlag(targetArgs, FLAG_TAG, new String[] {FLAG_TAG});
+            return new TagCommand(operation, index, tag);
+        } catch (NumberFormatException e) {
+            throw new ParseInvalidArgumentException("Index must be a valid integer", USAGE_TAG_COMMAND);
+        }
     }
 
     private static String requireTextFlag(String input, String flag, String[] knownFlags) {

--- a/src/test/java/seedu/cardcollector/StorageTest.java
+++ b/src/test/java/seedu/cardcollector/StorageTest.java
@@ -35,6 +35,8 @@ public class StorageTest {
                 .condition("Near Mint")
                 .language("English")
                 .cardNumber("58/102")
+                .addTag("deck")
+                .addTag("trade")
                 .build();
         inventory.addCard(activeCard);
         activeCard.setLastAdded(Instant.parse("2026-03-26T09:00:00Z"));
@@ -75,6 +77,8 @@ public class StorageTest {
         assertEquals("Pikachu", loadedActiveCard.getName());
         assertEquals("Base Set", loadedActiveCard.getCardSet());
         assertEquals("58/102", loadedActiveCard.getCardNumber());
+        assertEquals(true, loadedActiveCard.hasTag("deck"));
+        assertEquals(true, loadedActiveCard.hasTag("trade"));
         assertEquals(Instant.parse("2026-03-26T09:00:00Z"), loadedActiveCard.getLastAdded());
         assertNotNull(loadedWishlist.getCard(0).getLastAdded());
     }

--- a/src/test/java/seedu/cardcollector/card/CardsListTest.java
+++ b/src/test/java/seedu/cardcollector/card/CardsListTest.java
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CardsListTest {
 
@@ -45,7 +47,7 @@ public class CardsListTest {
                 .build());
 
         // Case-insensitive and partial match for "pika"
-        ArrayList<Card> results = cardsList.findCards("pika", null, null, null, null, null, null, null);
+        ArrayList<Card> results = cardsList.findCards("pika", null, null, null, null, null, null, null, null);
         
         assertEquals(2, results.size());
         assertEquals("Pikachu", results.get(0).getName());
@@ -68,7 +70,7 @@ public class CardsListTest {
                 .build());
 
         // Exact price match
-        ArrayList<Card> results = cardsList.findCards(null, 10.00f, null, null, null, null, null, null);
+        ArrayList<Card> results = cardsList.findCards(null, 10.00f, null, null, null, null, null, null, null);
         
         assertEquals(1, results.size());
         assertEquals("Charizard", results.get(0).getName());
@@ -90,7 +92,7 @@ public class CardsListTest {
                 .build());
 
         // Exact quantity match
-        ArrayList<Card> results = cardsList.findCards(null, null, 5, null, null, null, null, null);
+        ArrayList<Card> results = cardsList.findCards(null, null, 5, null, null, null, null, null, null);
         
         assertEquals(1, results.size());
         assertEquals("Bulbasaur", results.get(0).getName());
@@ -117,7 +119,7 @@ public class CardsListTest {
                 .build());
 
         // Matches both Name (contains "Mew") AND Quantity (exactly 3)
-        ArrayList<Card> results = cardsList.findCards("Mew", null, 3, null, null, null, null, null);
+        ArrayList<Card> results = cardsList.findCards("Mew", null, 3, null, null, null, null, null, null);
         
         assertEquals(2, results.size());
         assertEquals(20.00f, results.get(0).getPrice());
@@ -135,7 +137,7 @@ public class CardsListTest {
                 .build());
 
         // Searching for attributes that don't exist
-        ArrayList<Card> results = cardsList.findCards("Snorlax", 100.00f, null, null, null, null, null, null);
+        ArrayList<Card> results = cardsList.findCards("Snorlax", 100.00f, null, null, null, null, null, null, null);
         
         assertEquals(0, results.size());
     }
@@ -190,10 +192,37 @@ public class CardsListTest {
                 .build());
 
         ArrayList<Card> results = cardsList.findCards(
-                null, null, null, "base", "rare", "near", "english", "58/102");
+                null, null, null, "base", "rare", "near", "english", "58/102", null);
 
         assertEquals(1, results.size());
         assertEquals("Base Set", results.get(0).getCardSet());
+    }
+
+    @Test
+    public void addTagRemoveTagAndFindByTag_success() {
+        CardsList cardsList = new CardsList();
+        cardsList.addCard(new Card.Builder()
+                .name("Pikachu")
+                .price(5.50f)
+                .quantity(1)
+                .build());
+        cardsList.addCard(new Card.Builder()
+                .name("Charizard")
+                .price(99.99f)
+                .quantity(1)
+                .build());
+
+        assertTrue(cardsList.addTag(0, "deck"));
+        assertFalse(cardsList.addTag(0, "deck"));
+        assertTrue(cardsList.getCard(0).hasTag("DECK"));
+
+        ArrayList<Card> taggedResults = cardsList.findCards(
+                null, null, null, null, null, null, null, null, "deck");
+        assertEquals(1, taggedResults.size());
+        assertEquals("Pikachu", taggedResults.get(0).getName());
+
+        assertTrue(cardsList.removeTag(0, "deck"));
+        assertFalse(cardsList.getCard(0).hasTag("deck"));
     }
 
     @Test

--- a/src/test/java/seedu/cardcollector/parsing/ParserTest.java
+++ b/src/test/java/seedu/cardcollector/parsing/ParserTest.java
@@ -8,8 +8,11 @@ import seedu.cardcollector.command.RemoveCardByNameCommand;
 import seedu.cardcollector.command.HistoryCommand;
 import seedu.cardcollector.command.Command;
 import seedu.cardcollector.command.DownloadCommand;
+import seedu.cardcollector.command.FindCommand;
 import seedu.cardcollector.command.UploadCommand;
 import seedu.cardcollector.command.UndoUploadCommand;
+import seedu.cardcollector.command.ListCommand;
+import seedu.cardcollector.command.TagCommand;
 import seedu.cardcollector.exception.ParseBlankCommandException;
 import seedu.cardcollector.exception.ParseInvalidArgumentException;
 import seedu.cardcollector.exception.ParseUnknownCommandException;
@@ -240,6 +243,30 @@ public class ParserTest {
         assertThrows(
                 ParseInvalidArgumentException.class,
                 () -> parser.parse("undoupload now")
+        );
+    }
+
+    @Test
+    public void parse_tagAndTagFilterCommands_success() throws Exception {
+        assertInstanceOf(FindCommand.class, parser.parse("find /t trade"));
+        assertInstanceOf(ListCommand.class, parser.parse("list /t sealed"));
+        assertInstanceOf(TagCommand.class, parser.parse("tag add 3 /t deck"));
+        assertInstanceOf(TagCommand.class, parser.parse("folder remove 2 /t trade"));
+    }
+
+    @Test
+    public void parse_invalidTagCommands_exceptionThrown() {
+        assertThrows(
+                ParseInvalidArgumentException.class,
+                () -> parser.parse("tag add /t deck")
+        );
+        assertThrows(
+                ParseInvalidArgumentException.class,
+                () -> parser.parse("tag move 1 /t deck")
+        );
+        assertThrows(
+                ParseInvalidArgumentException.class,
+                () -> parser.parse("list sealed")
         );
     }
 


### PR DESCRIPTION
Cards now carry optional tags, display them when present, and persist them in storage with backward-compatible load support for older save files in Card.java and Storage.java.

The parser now accepts tag add INDEX /t TAG, tag remove INDEX /t TAG, folder ... as an alias, plus /t filters for find and list in Parser.java. 

Tag mutations are also undoable via the new TagCommand.java, and list/find filtering runs through CardsList.java.