### PR TITLE
Fix a bug in which `wishlist` alone shows unknown command

### DIFF
--- a/src/main/java/seedu/cardcollector/CardCollector.java
+++ b/src/main/java/seedu/cardcollector/CardCollector.java
@@ -48,13 +48,10 @@ public class CardCollector {
             if (input.toLowerCase().startsWith("wishlist ")) {
                 isWishlistCommand = true;
                 parseInput = input.substring(9).trim();
-            }
-
-            // Prevent "wishlist" alone from crashing parser
-            if (parseInput.isEmpty()) {
-                if (isWishlistCommand) {
-                    ui.printUnknownCommandWarning("wishlist");
-                }
+            } else if(input.equalsIgnoreCase("wishlist")) {
+                // Handles "wishlist" without any subsequent command
+                ui.printInvalidArgumentWarning("Wishlist must be followed by a valid command",
+                        new String[] {"wishlist COMMAND"});
                 continue;
             }
 

--- a/src/main/java/seedu/cardcollector/CardCollector.java
+++ b/src/main/java/seedu/cardcollector/CardCollector.java
@@ -48,7 +48,7 @@ public class CardCollector {
             if (input.toLowerCase().startsWith("wishlist ")) {
                 isWishlistCommand = true;
                 parseInput = input.substring(9).trim();
-            } else if(input.equalsIgnoreCase("wishlist")) {
+            } else if (input.equalsIgnoreCase("wishlist")) {
                 // Handles "wishlist" without any subsequent command
                 ui.printInvalidArgumentWarning("Wishlist must be followed by a valid command",
                         new String[] {"wishlist COMMAND"});

--- a/src/main/java/seedu/cardcollector/parsing/Parser.java
+++ b/src/main/java/seedu/cardcollector/parsing/Parser.java
@@ -165,6 +165,15 @@ public class Parser {
         "upload /f backups/cardcollector.txt"
     };
 
+    /**
+     * Parses the input string and returns a created command.
+     *
+     * @param input The raw string to parse.
+     * @return The created command.
+     * @throws ParseBlankCommandException    If the input is empty or contains only whitespace.
+     * @throws ParseUnknownCommandException  If the command keyword is not recognized.
+     * @throws ParseInvalidArgumentException If the command arguments are invalid.
+     */
     public Command parse(String input) throws
             ParseBlankCommandException,
             ParseUnknownCommandException,


### PR DESCRIPTION
This also fixes the bug when a empty string is entered, but nothing happens